### PR TITLE
MID-8834 Fix and re-enable test120ApproveCaseAction

### DIFF
--- a/schrodinger-framework/src/main/java/com/evolveum/midpoint/schrodinger/component/cases/OperationRequestPanel.java
+++ b/schrodinger-framework/src/main/java/com/evolveum/midpoint/schrodinger/component/cases/OperationRequestPanel.java
@@ -37,10 +37,9 @@ public class OperationRequestPanel extends Component<CasePage, OperationRequestP
     }
 
     public boolean changesAreApplied(){
-        return $(Schrodinger.byDataId("operationRequestCasePanel"))
-                .shouldBe(Condition.visible, MidPoint.TIMEOUT_DEFAULT_2_S)
-                .$(By.className("card-success"))
-                .$(byText("Changes applied (successfully or not)"))
+        SelenideElement panel = $(Schrodinger.byDataId("operationRequestCasePanel"))
+                .shouldBe(Condition.visible, MidPoint.TIMEOUT_DEFAULT_2_S);
+        return panel.$(byText("Changes applied (successfully or not)"))
                 .is(Condition.visible);
     }
 

--- a/schrodinger-tests/src/test/java/com/evolveum/midpoint/schrodinger/scenarios/CaseTests.java
+++ b/schrodinger-tests/src/test/java/com/evolveum/midpoint/schrodinger/scenarios/CaseTests.java
@@ -108,11 +108,10 @@ public class CaseTests extends AbstractSchrodingerTest {
 
      }
 
-     //commented due to MID-8834
-//    @Test (dependsOnMethods = {"test110isCaseCreated"})
+    @Test (dependsOnMethods = {"test110isCaseCreated"})
     public void test120approveCaseAction() {
-        AllRequestsPage allRequestsPage = basicPage.listAllRequests();
-        ChildrenCaseTable childrenCaseTable = allRequestsPage
+        AllCasesPage allCasesPage = basicPage.listAllCases();
+        ChildrenCaseTable childrenCaseTable = allCasesPage
                 .table()
                 .search()
                 .byName()
@@ -138,8 +137,8 @@ public class CaseTests extends AbstractSchrodingerTest {
 
         Selenide.sleep(MidPoint.TIMEOUT_MEDIUM_6_S.getSeconds());
 
-        allRequestsPage = basicPage.listAllRequests();
-        CasePage casePage = allRequestsPage
+        allCasesPage = basicPage.listAllCases();
+        CasePage casePage = allCasesPage
                 .table()
                 .search()
                 .byName()


### PR DESCRIPTION
Re-enabled and fixed **test120approveCaseAction** after work item search fix (MID-8834).

Updated test to use All cases, aligning with current UI behavior, data model and other tests in class.
Also stabilized **changesAreApplied()** check by scoping assertions to the panel element.