### PR TITLE
MID-10908 Add Schrodinger test for More popover tooltips

### DIFF
--- a/schrodinger-framework/src/main/java/com/evolveum/midpoint/schrodinger/component/common/search/Search.java
+++ b/schrodinger-framework/src/main/java/com/evolveum/midpoint/schrodinger/component/common/search/Search.java
@@ -246,6 +246,48 @@ public class Search<T> extends Component<T, Search<T>> {
         return link;
     }
 
+    /**
+     * Verifies that a help tooltip in the More popover opens once and is cleaned up on mouse leave and popover close.
+     */
+    public void assertMorePopoverHelpTooltipLifecycle(String itemName, String expectedTooltipText) {
+        SelenideElement popover = getMorePopover();
+        SelenideElement help = getMorePopoverItemHelp(popover, itemName);
+        help.hover();
+
+        visibleTooltips().shouldHave(CollectionCondition.size(1), MidPoint.TIMEOUT_MEDIUM_6_S);
+        visibleTooltips().first().shouldHave(Condition.text(expectedTooltipText), MidPoint.TIMEOUT_DEFAULT_2_S);
+
+        popover.$("input[aria-label='Search item']").hover();
+        visibleTooltips().shouldHave(CollectionCondition.size(0), MidPoint.TIMEOUT_MEDIUM_6_S);
+
+        help.hover();
+        visibleTooltips().shouldHave(CollectionCondition.size(1), MidPoint.TIMEOUT_MEDIUM_6_S);
+        popover.$x(".//a[contains(@class, 'btn-default')]")
+                .shouldBe(Condition.visible, MidPoint.TIMEOUT_DEFAULT_2_S)
+                .click();
+        popover.shouldBe(Condition.hidden, MidPoint.TIMEOUT_MEDIUM_6_S);
+        visibleTooltips().shouldHave(CollectionCondition.size(0), MidPoint.TIMEOUT_MEDIUM_6_S);
+
+    }
+
+    /**
+     * Finds the help icon that belongs to a named search item in the More popover.
+     */
+    private SelenideElement getMorePopoverItemHelp(SelenideElement popover, String itemName) {
+        SelenideElement itemNameElement = findSearchItemByNameLinkInMorePopover(popover, itemName);
+        assertion.assertNotNull(itemNameElement, "Search item '" + itemName + "' should be visible in More popover.");
+        return itemNameElement
+                .parent()
+                .parent()
+                .parent()
+                .$(Schrodinger.byDataId("i", "itemHelp"))
+                .shouldBe(Condition.visible, MidPoint.TIMEOUT_DEFAULT_2_S);
+    }
+
+    private ElementsCollection visibleTooltips() {
+        return $$(".tooltip").filter(Condition.visible);
+    }
+
     private SelenideElement getMorePopover() {
         choiceBasicSearch();
         getMoreDropdownButtonElement()
@@ -452,4 +494,3 @@ public class Search<T> extends Component<T, Search<T>> {
     }
 
 }
-

--- a/schrodinger-tests/src/test/java/com/evolveum/midpoint/schrodinger/component/SearchPanelTest.java
+++ b/schrodinger-tests/src/test/java/com/evolveum/midpoint/schrodinger/component/SearchPanelTest.java
@@ -155,6 +155,21 @@ public class SearchPanelTest extends AbstractSchrodingerTest {
                 .assertSearchItemExists(ROLE_MEMBERSHIP_ATTRIBUTE);
     }
 
+    /**
+     * Covers MID-10908: help tooltips in the search More popover must not
+     * duplicate, remain stuck, or survive mouse leave/popover close.
+     */
+    @Test
+    public void test0035morePopoverHelpTooltipLifecycle() {
+        basicPage
+                .listUsers()
+                .table()
+                .search()
+                .assertMorePopoverHelpTooltipLifecycle(
+                        ADMINISTRATIVE_STATUS_ATTRIBUTE,
+                        "Filter by administrative status.");
+    }
+
     @Test
     public void test0040booleanAttributeSearch() {
         reloginAsAdministrator();


### PR DESCRIPTION
## Summary

Adds Schrodinger coverage for MID-10908 to verify the lifecycle of help tooltips in the search `More` popover.

The new test checks that a help tooltip:

- opens as a single visible tooltip
- contains the expected text
- is hidden after moving the mouse away from the help icon
- can be opened again
- is cleaned up when the `More` popover is closed

This covers the reported cases where tooltips could blink, remain stuck, duplicate, or survive after the popover was closed.
